### PR TITLE
refactored get_intendeded_restaurant

### DIFF
--- a/src/input.py
+++ b/src/input.py
@@ -33,19 +33,20 @@ def get_intended_restaurant(yelp_potential_matches: list) -> tuple:
     # if there's only one potential match, return it
     if len(yelp_potential_matches) == 1:
         return yelp_potential_matches[0]
-    
-    # otherwise, determine the intended restaurant
-    for i in range(len(yelp_potential_matches)):
-        print(str(i) + ": " + str(yelp_potential_matches[i][1] + " - " + yelp_potential_matches[i][2]))  
 
     # continuously prompt user to indicate their intended restaurant until they provide valid input 
     while True:
-        try:    
+        try:
+            for i in range(len(yelp_potential_matches)):
+                print(str(i) + ": " + str(yelp_potential_matches[i][1] + " - " + yelp_potential_matches[i][2]))      
             print("Enter the number corresponding to the restaurant you had in mind\nOR\nnot seeing the restaurant you were looking for? Enter -1 to search again!")
             selected_index = int(input("Enter your selection: "))
-
             if selected_index == -1:
                 raise IntendedRestaurantNotFoundError
+            
+            # python allows negative indexing, but we still raise an error as the number should correspond to the list
+            elif selected_index < -1:
+                raise IndexError
             intended_restaurant = yelp_potential_matches[selected_index]
             break
         except (IndexError, ValueError):

--- a/test/test_input.py
+++ b/test/test_input.py
@@ -28,10 +28,17 @@ def test_get_intended_restaurant_multiple_matches(mock_input: Mock):
     actual = input.get_intended_restaurant(yelp_potential_matches)
     assert actual == expected
 
-@patch('builtins.input', side_effect=["2", "0"])
+@pytest.mark.parametrize("side_effect", [
+    ["2", "0"], # invalid index: out of bounds positive
+    ["-2", "0"], # invalid index: out of bounds negative
+    ["a", "0"], # letter given
+    ["", "0"] # empty string given
+])
 @patch('builtins.print')
-def test_get_intended_restaurant_index_error_out_of_range(mock_print: Mock, mock_input: Mock):
+@patch('builtins.input')
+def test_get_intended_restaurant_errors(mock_input, mock_print, side_effect):
     yelp_potential_matches = [("page 1", "name 1", "location 1"), ("page 2", "name 2", "location 2")]
+    mock_input.side_effect = side_effect
     input.get_intended_restaurant(yelp_potential_matches)
     mock_print.assert_any_call("The number you enter must correspond to one of the listed restaurants.")
 
@@ -40,22 +47,6 @@ def test_get_intended_restaurant_index_error_negative_one(mock_input: Mock):
     yelp_potential_matches = [("page 1", "name 1", "location 1"), ("page 2", "name 2", "location 2")]
     with pytest.raises(IntendedRestaurantNotFoundError):
         input.get_intended_restaurant(yelp_potential_matches)
-
-@patch('builtins.input', side_effect=["a", "0"])
-@patch('builtins.print')
-def test_get_intended_restaurant_value_error_letter_given(mock_print: Mock, mock_input: Mock):
-    yelp_potential_matches = [("page 1", "name 1", "location 1"), ("page 2", "name 2", "location 2")]
-    input.get_intended_restaurant(yelp_potential_matches)
-    mock_print.assert_any_call("The number you enter must correspond to one of the listed restaurants.")
-
-@patch('builtins.input', side_effect=["", "0"])
-@patch('builtins.print')
-def test_get_intended_restaurant_value_error_empty_string(mock_print: Mock, mock_input: Mock):
-    yelp_potential_matches = [("page 1", "name 1", "location 1"), ("page 2", "name 2", "location 2")]
-    input.get_intended_restaurant(yelp_potential_matches)
-    mock_print.assert_any_call("The number you enter must correspond to one of the listed restaurants.")
-
-
 
 
     


### PR DESCRIPTION
- _get_intendeded_restaurant_ now displays the list of yelp matches again after invalid input
- _get_intendeded_restaurant_ now raises an Index Error when a negative index (besides -1) is provided
- Added _get_intendeded_restaurant_ unit test to check that Index Error is raised when a negative number (besides -1) is provided
- Parametrized _test_input.py_ unit tests