### PR TITLE
finished handling case when rating can't be parsed

### DIFF
--- a/src/calculate_weighted_average.py
+++ b/src/calculate_weighted_average.py
@@ -11,13 +11,15 @@ def get_weighted_average_and_total_review_count(site_ratings: list):
     """
     total_stars = 0
     total_review_count = 0
-    for site_rating in site_ratings:
-        rating = float(site_rating[1])
+    for _, star_rating, review_count in site_ratings:
+        # if we were unable to find the rating for the site, we don't consider the site when calculating the weighted average
+        if star_rating is not None:
 
-        # remove the commas so review_count can be converted into an integer
-        review_count = int(site_rating[2].replace(',', ''))  
-        total_stars += rating * review_count
-        total_review_count += review_count
+            # remove the commas so review_count can be converted into an integer
+            review_count = int(review_count.replace(',', ''))  
+            total_stars += float(star_rating) * review_count
+            total_review_count += review_count
+    
     weighted_average = total_stars / total_review_count
     
     # add commas to the total review count to be consistent with the review counts for individual sites

--- a/src/input.py
+++ b/src/input.py
@@ -29,7 +29,7 @@ def read_input() -> tuple:
 def get_intended_restaurant(yelp_potential_matches: list) -> tuple:
     """
     Allows the user to select their intended restaurant from a list of potential matches (if multiple matches exist)
-    :param list search_results - a list of tuples, where each tuple is in the form (<website page>, <name>, <address>)
+    :param list search_results - a list of tuples, where each tuple is in the form (<website page>, <restaurant name>, <address>)
     :return tuple intended_restaurant - a tuple representing the restaurant selected by the user, in the form (<website page>, <name>, <address>)
     :raises IntendedRestaurantNotFoundError - if user enters -1, indicating that the restaurant they're looking was not one of the yelp matches
     """
@@ -60,13 +60,17 @@ def get_intended_restaurant(yelp_potential_matches: list) -> tuple:
 def output_site_ratings(site_ratings: list, full_name: str, address: str):
     """
     Displays the ratings of the websites
-    :param list site_ratings - a list of tuples, where each tuple is in the form (<website>, <rating>, <number of reviews>)
+    :param list site_ratings - a list of tuples, where each tuple is in the form (<website name>, <rating>, <number of reviews>)
     :param str full_name - the full name of the restaurant
     :param str address - the address of the restaurant
     """
     print(get_styled_output(f"Showing Results for {full_name} - {address}...", MessageType.INFO))
-    for site_rating in site_ratings:
-        print(get_styled_output(f"{site_rating[0]} - {site_rating[1]} stars, {site_rating[2]} reviews", MessageType.LIST_RESULT))
+    for website_name, star_rating, review_count in site_ratings:
+        if star_rating is None:
+            display_message = f"{website_name} - Ratings could not be found for this site, it will not be considred for the aggregate rating"
+        else:
+            display_message = f"{website_name} - {star_rating} stars, {review_count} reviews"
+        print(get_styled_output(display_message, MessageType.LIST_RESULT))
 
 def display_results(full_name: str, star_average: str, total_review_count: str):
     """
@@ -76,7 +80,6 @@ def display_results(full_name: str, star_average: str, total_review_count: str):
     :param str total_review_count - the sum of the review counts across all scraped websites
     """
     print(get_styled_output(f"{Style.BRIGHT}A more accurate rating of {full_name} is {star_average} stars, {total_review_count} reviews{Style.RESET_ALL}", MessageType.FINAL_RESULT))
-
 
 def display_welcome_message():
     """

--- a/src/main.py
+++ b/src/main.py
@@ -4,7 +4,6 @@ It reads the user input, scrapes the ratings and review counts for the given res
 Author: Noah Landis
 """
 
-import sys
 import time
 from cli_command import prompt_next_command
 from scrape import scrape

--- a/src/model/google.py
+++ b/src/model/google.py
@@ -23,7 +23,7 @@ class Google(Website):
         return f"{Google.ROOT}/search?q={name} {city}"
 
     @staticmethod
-    def get_rating_and_review_count(page: BeautifulSoup) -> tuple:
+    def _get_rating_and_review_count(page: BeautifulSoup) -> tuple:
         """
         Scrapes the rating and review count from the Google page
         :param BeautifulSoup page - the page to scrape

--- a/src/model/tripadvisor.py
+++ b/src/model/tripadvisor.py
@@ -23,13 +23,12 @@ class TripAdvisor(Website):
         return Google.build_url(name, city)
 
     @staticmethod
-    def get_rating_and_review_count(page: BeautifulSoup) -> tuple:
+    def _get_rating_and_review_count(page: BeautifulSoup) -> tuple:
         """
         Scrapes the rating and review count from the TripAdvisor rich snippet
         :param BeautifulSoup page - the page to scrape
         :return tuple (<rating>, <review_count>) - the rating and review count for the restaurant
         """
-
         # find the div that contains the tripadvisor link
         div = page.find('div', class_='BNeawe UPmit AP7Wnd lRVwie', string=re.compile('www.tripadvisor.com'))
         trip_advisor_description = div.parent.parent.parent.parent.next_sibling

--- a/src/model/website.py
+++ b/src/model/website.py
@@ -13,7 +13,7 @@ class Website(ABC):
     
     @staticmethod
     @abstractmethod
-    def build_url(self, name: str, city: str) -> str:
+    def build_url(name: str, city: str) -> str:
         """
         Builds the URL to search for a restaurant on the website
         :param str name - the name of the restaurant
@@ -22,15 +22,24 @@ class Website(ABC):
         """
         pass
 
-    @staticmethod
-    @abstractmethod
-    def get_rating_and_review_count(self, page: BeautifulSoup) -> tuple:
+    @classmethod
+    def get_rating_and_review_count(cls, page: BeautifulSoup) -> tuple:
         """
         Scrapes the rating and review count from the given page
         :param BeautifulSoup page - the page to scrape
-        :return tuple (<rating>, <review_count>) - the rating and review count for the restaurant
+        :return tuple (<rating>, <review_count>) - the rating and review count for the restaurant, or (<None>, <None>) if the rating and review couldn't be parsed
         """
+        try:
+            return cls._get_rating_and_review_count(page)
+        # handle case when the rating and review count couldn't be parsed
+        except AttributeError:
+            return None, None
+        
+    @staticmethod
+    @abstractmethod
+    def _get_rating_and_review_count(page: BeautifulSoup) -> tuple:
         pass
-    
+
+
 
 

--- a/src/model/yelp.py
+++ b/src/model/yelp.py
@@ -21,7 +21,7 @@ class Yelp(Website):
         return f"{Yelp.ROOT}/search?find_desc={name}&find_loc={city}"
 
     @staticmethod
-    def get_rating_and_review_count(page: BeautifulSoup) -> tuple:
+    def _get_rating_and_review_count(page: BeautifulSoup) -> tuple:
         """
         Scrapes the rating and review count from the Yelp page
         :param BeautifulSoup page - the page to scrape

--- a/test/test_calculate_weighted_average.py
+++ b/test/test_calculate_weighted_average.py
@@ -5,6 +5,7 @@ from src.calculate_weighted_average import get_weighted_average_and_total_review
     ([("Yelp", "1.0", "1"), ("Google", "5.0", "1")], (3.0, "2")), # weighted average and count is calculated correctly
     ([("Yelp", "1.0", "1"), ("Google", "5.0", "2")], (3.67, "3")), # weighted average is correctly rounded
     ([("Yelp", "1.0", "1,000")], (1.0, "1,000")), # commas are formatted correctly
+    ([("Yelp", "1.0", "1"), ("Google", None, None)], (1.0, "1")) # ratings that couldn't be found aren't factored into calculation
 ])
 def test_get_weighted_average_and_total_review_count(site_ratings, expected):
     actual = get_weighted_average_and_total_review_count(site_ratings)

--- a/test/test_google.py
+++ b/test/test_google.py
@@ -1,3 +1,4 @@
+from bs4 import BeautifulSoup
 from src.model.google import Google
 
 def test_build_url():
@@ -8,4 +9,17 @@ def test_build_url():
 def test_build_url_with_ampersand():
     expected = "https://www.google.com/search?q=Jordan's Restaurant and Pizza Norwalk"
     actual = Google.build_url("Jordan's Restaurant & Pizza", "Norwalk")
+    assert actual == expected
+
+def test_get_rating_and_review_count_google():
+    expected = ("4.5", "1,000")
+    html = '''
+        <div class="BNeawe tAd8D AP7Wnd">
+            <span class="oqSTJd">4.5</span>
+            <span> • </span>
+            <span>1,000 reviews</span>
+        </div>
+        '''
+    page = BeautifulSoup(html, 'html.parser')
+    actual = Google.get_rating_and_review_count(page)
     assert actual == expected

--- a/test/test_tripadvisor.py
+++ b/test/test_tripadvisor.py
@@ -1,6 +1,16 @@
+from bs4 import BeautifulSoup
 from src.model.tripadvisor import TripAdvisor
 
 def test_build_url():
     expected = "https://www.google.com/search?q=Home Slice Pizza Austin"
     actual = TripAdvisor.build_url("Home Slice Pizza", "Austin")
+    assert actual == expected
+
+def test_get_rating_and_review_count_tripadvisor():
+    expected = ("4.5", "1,000")
+    html =  '''
+         <div><div class="Gx5Zad fP1Qef xpd EtOod pkphOe"><div class="egMi0 kCrYT"><a href="/url?esrc=s&amp;q=&amp;rct=j&amp;sa=U&amp;url=https://www.tripadvisor.com/Restaurant_Review-g30196-d18095194-Reviews-Home_Slice_Pizza-Austin_Texas.html&amp;ved=2ahUKEwjtp5f2_tiGAxXvk4kEHXjJC1YQFnoECAYQAg&amp;usg=AOvVaw3wB5AqT0vSUygUYJ5yg9Cl" data-ved="2ahUKEwjtp5f2_tiGAxXvk4kEHXjJC1YQFnoECAYQAg"><div class="DnJfK"><div class="j039Wc"><h3 class="zBAuLc l97dzf"><div class="BNeawe vvjwJb AP7Wnd">HOME SLICE PIZZA, Austin - 501 E 53rd St - Tripadvisor</div></h3></div><div class="sCuL3"><div class="BNeawe UPmit AP7Wnd lRVwie">www.tripadvisor.com › United States › Texas (TX) › Austin</div></div></div></a></div><div class="kCrYT"><div><div class="BNeawe s3v9rd AP7Wnd"><div><div class="v9i61e"><div class="BNeawe s3v9rd AP7Wnd"><span class="r0bn4c rQMQod">Rating</span> <span class="r0bn4c rQMQod tP9Zud"><span> </span><span aria-hidden="true" class="oqSTJd">4.5</span><span> </span><div class="Hk2yDb KsR1A" aria-label="Rated 4.5 out of 5" role="img"><span style="width:52px"></span></div><span> </span><span>(1,000)</span><span> </span></span> <span class="r0bn4c rQMQod"> · </span><span class="r0bn4c rQMQod">$$ - $$$</span></div></div><div><div class="BNeawe s3v9rd AP7Wnd">13 reviews#681 of 1,901 Restaurants in Austin$$ - $$$ItalianPizza. 501 E 53rd St, Austin, TX 78751-2103 +1 512-707-7437 Website. Closed now: See all hours.</div></div></div></div></div></div></div></div>
+        '''
+    page = BeautifulSoup(html, 'html.parser')
+    actual = TripAdvisor.get_rating_and_review_count(page)
     assert actual == expected

--- a/test/test_website.py
+++ b/test/test_website.py
@@ -1,0 +1,13 @@
+
+from unittest.mock import Mock
+from bs4 import BeautifulSoup
+from src.model.yelp import Yelp
+from src.model.google import Google
+from src.model.tripadvisor import TripAdvisor
+
+def test_get_rating_and_review_count_cant_parse():
+    expected = (None, None)
+    html = "<div></div>"
+    page = BeautifulSoup(html, 'html.parser')
+    actual = Yelp.get_rating_and_review_count(page)
+    assert actual == expected

--- a/test/test_yelp.py
+++ b/test/test_yelp.py
@@ -1,6 +1,19 @@
+from bs4 import BeautifulSoup
 from src.model.yelp import Yelp
 
 def test_build_url():
     expected = "https://www.yelp.com/search?find_desc=Home Slice Pizza&find_loc=Austin"
     actual = Yelp.build_url("Home Slice Pizza", "Austin")
+    assert actual == expected
+
+def test_get_rating_and_review_count_yelp():
+    expected = ("4.5", "1,000")
+    html = '''
+        <div class="arrange-unit__09f24__rqHTg arrange-unit-fill__09f24__CUubG y-css-lbeyaq">
+            <span>4.5</span>
+            <span>1,000 reviews</span>
+        </div>
+        '''
+    page = BeautifulSoup(html, 'html.parser')
+    actual = Yelp.get_rating_and_review_count(page)
     assert actual == expected


### PR DESCRIPTION
- Modified _get_rating_and_review_count_ to return (None, None) whenever a rating from a particular website can't be parsed
- Modified _output_site_ratings_ to indicate to user when a website's ratings were unable to be parsed
- Modified _get_weighted_average_and_total_review_count_ to not factor in websites where the ratings couldn't be found into the calculation